### PR TITLE
Making bash commands compatible with OSX

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/util.sh
 
 desc "Nuke it all"
 run "kubectl delete namespace demos"

--- a/daemon_sets/demo.sh
+++ b/daemon_sets/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 for NODE in $(kubectl get nodes -o name | cut -f2 -d/); do
     kubectl label node $NODE color- --overwrite >/dev/null 2>&1
@@ -20,6 +20,6 @@ run "kubectl --namespace=demos create -f $(relative daemon.yaml) --validate=fals
 run "kubectl --namespace=demos describe ds daemons-demo"
 
 tmux new -d -s my-session \
-    "$(dirname ${BASH_SOURCE})/split1_lhs.sh" \; \
+    "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/split1_lhs.sh" \; \
     split-window -h -d "sleep 10; $(dirname $BASH_SOURCE)/split1_rhs.sh" \; \
     attach \;

--- a/daemon_sets/split1_lhs.sh
+++ b/daemon_sets/split1_lhs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 IP=$(kubectl --namespace=demos get svc daemon-demo \
         -o go-template='{{.spec.clusterIP}}')

--- a/daemon_sets/split1_rhs.sh
+++ b/daemon_sets/split1_rhs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Color each node, slowly"
 run "for NODE in \$(kubectl get nodes -o name | grep -v master | cut -f2 -d/); do \\

--- a/deployments/demo.sh
+++ b/deployments/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Create a service that fronts any version of this demo"
 run "cat $(relative svc.yaml)"
@@ -14,6 +14,6 @@ desc "Check it"
 run "kubectl --namespace=demos describe deployment deployment-demo"
 
 tmux new -d -s my-session \
-    "$(dirname ${BASH_SOURCE})/split1_lhs.sh" \; \
+    "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/split1_lhs.sh" \; \
     split-window -h -d "sleep 10; $(dirname $BASH_SOURCE)/split1_rhs.sh" \; \
     attach \;

--- a/deployments/split1_lhs.sh
+++ b/deployments/split1_lhs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 IP=$(kubectl --namespace=demos get svc deployment-demo \
         -o go-template='{{.spec.clusterIP}}')

--- a/deployments/split1_rhs.sh
+++ b/deployments/split1_rhs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Update the deployment"
 run "cat $(relative deployment.yaml) | sed 's/ v1/ v2/g' | kubectl --namespace=demos apply -f- --validate=false"

--- a/graceful_termination/demo.sh
+++ b/graceful_termination/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Create a pod"
 run "cat $(relative pod.yaml)"

--- a/jobs/demo.sh
+++ b/jobs/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Run some pods in a job"
 run "cat $(relative job.yaml)"

--- a/pod_autoscalers/demo.sh
+++ b/pod_autoscalers/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Run some pods under a replication controller"
 run "kubectl --namespace=demos run yes-autoscaler-demo \\

--- a/pods/demo.sh
+++ b/pods/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "There are no running pods"
 run "kubectl --namespace=demos get pods"

--- a/quota/demo.sh
+++ b/quota/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "There is no quota"
 run "kubectl --namespace=demos get quota"

--- a/replication_controllers/demo.sh
+++ b/replication_controllers/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Run some pods under a replication controller"
 run "kubectl --namespace=demos run hostnames \\

--- a/rolling_update/demo.sh
+++ b/rolling_update/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Create a service that fronts any version of this demo"
 run "cat $(relative svc.yaml)"
@@ -11,6 +11,6 @@ run "cat $(relative rc-v1.yaml)"
 run "kubectl --namespace=demos create -f $(relative rc-v1.yaml)"
 
 tmux new -d -s my-session \
-    "$(dirname ${BASH_SOURCE})/split1_lhs.sh" \; \
+    "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/split1_lhs.sh" \; \
     split-window -h -d "sleep 10; $(dirname $BASH_SOURCE)/split1_rhs.sh" \; \
     attach \;

--- a/rolling_update/split1_lhs.sh
+++ b/rolling_update/split1_lhs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 IP=$(kubectl --namespace=demos get svc update-demo \
         -o go-template='{{.spec.clusterIP}}')

--- a/rolling_update/split1_rhs.sh
+++ b/rolling_update/split1_rhs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Do a rolling update to v2"
 run "cat $(relative rc-v2.yaml)"

--- a/secrets/demo.sh
+++ b/secrets/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Create a secret"
 run "cat $(relative secret.yaml)"

--- a/services/demo.sh
+++ b/services/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 if kubectl --namespace=demos get rc hostnames >/dev/null 2>&1; then
     desc "Revisit our replication controller"
@@ -33,6 +33,6 @@ run "gcloud compute ssh --zone=us-central1-b $SSH_NODE --command '\\
     '"
 
 tmux new -d -s my-session \
-    "$(dirname ${BASH_SOURCE})/split1_lhs.sh" \; \
+    "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/split1_lhs.sh" \; \
     split-window -h -d "sleep 10; $(dirname $BASH_SOURCE)/split1_rhs.sh" \; \
     attach \;

--- a/services/split1_lhs.sh
+++ b/services/split1_lhs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 IP=$(kubectl --namespace=demos get svc hostnames \
         -o go-template='{{.spec.clusterIP}}')

--- a/services/split1_rhs.sh
+++ b/services/split1_rhs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/../util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../util.sh
 
 desc "Resize the RC and watch the service backends change"
 run "kubectl --namespace=demos scale rc hostnames --replicas=1"

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname ${BASH_SOURCE})/util.sh
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/util.sh
 
 desc "The demo namespace does not exist"
 run "kubectl get namespaces"

--- a/util.sh
+++ b/util.sh
@@ -5,6 +5,10 @@ readonly  green=$(tput bold; tput setaf 2)
 readonly yellow=$(tput bold; tput setaf 3)
 readonly   blue=$(tput bold; tput setaf 6)
 
+function realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
 function desc() {
     maybe_first_prompt
     echo "$blue# $@$reset"
@@ -35,7 +39,7 @@ function run() {
     fi
     eval "$1"
     r=$?
-    read -d '' -t 0.1 -n 10000 # clear stdin
+    read -d '' -t 1 -n 10000 # clear stdin
     prompt
     if [ -z "$DEMO_AUTO_RUN" ]; then
       read -s


### PR DESCRIPTION
Hi @thockin, it's pretty impressive how you have automated k8s demos using ```pv```. I tried it on OSX but it did not work due to three reasons. I fixed those while preserving the compatibility with Ubuntu/Debian. 

Following are the changes I have done in this PR, please let me know your thoughts on this:

1. Changed ```$(dirname ${BASH_SOURCE})``` to ```$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )```
2. Added realpath function:
    ```
    function realpath() {
        [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
    }
    ```
3. Changed -t 0.1 to -t 1 in ```read -d '' -t 1 -n 10000 # clear stdin```